### PR TITLE
HHVM-171: Manager::selectServer() should select exception class based on bson_error_t

### DIFF
--- a/src/MongoDB/Driver/Manager.cpp
+++ b/src/MongoDB/Driver/Manager.cpp
@@ -618,7 +618,7 @@ Object HHVM_METHOD(MongoDBDriverManager, selectServer, const Object &readPrefere
 		mongoc_server_description_destroy(selected_server);
 		return tmp;
 	} else {
-		throw MongoDriver::Utils::throwRunTimeException(error.message);
+		throw MongoDriver::Utils::throwExceptionFromBsonError(&error);
 	}
 }
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/HHVM-171

This fixes HHVM test compatibility with https://github.com/mongodb/mongo-php-driver/pull/231.