### PR TITLE
HHVM-196: Manager::getServers() should use mongoc_client_get_server_descriptions()

### DIFF
--- a/bson.cpp
+++ b/bson.cpp
@@ -18,6 +18,7 @@
 #include "hphp/runtime/base/array-iterator.h"
 #include "hphp/runtime/base/execution-context.h"
 #include "hphp/runtime/base/type-string.h"
+#include "hphp/util/logger.h"
 
 #include "bson.h"
 #include "utils.h"

--- a/tests/MongoDBDriverManager_debugInfo.phpt
+++ b/tests/MongoDBDriverManager_debugInfo.phpt
@@ -1,0 +1,62 @@
+--TEST--
+MongoDB\Driver\Manager::__debugInfo()
+--FILE--
+<?php
+$manager = new MongoDB\Driver\Manager();
+
+$command = new MongoDB\Driver\Command(array('ping' => 1));
+$manager->executeCommand("test", $command);
+
+var_dump( $manager->__debugInfo() );
+?>
+--EXPECTF--
+array(2) {
+  ["uri"]=>
+  string(%d) "%s"
+  ["cluster"]=>
+  array(1) {
+    [0]=>
+    array(10) {
+      ["host"]=>
+      string(%d) "%s"
+      ["port"]=>
+      int(%d)
+      ["type"]=>
+      int(1)
+      ["is_primary"]=>
+      bool(false)
+      ["is_secondary"]=>
+      bool(false)
+      ["is_arbiter"]=>
+      bool(false)
+      ["is_hidden"]=>
+      bool(false)
+      ["is_passive"]=>
+      bool(false)
+      ["last_is_master"]=>
+      array(8) {
+        ["ismaster"]=>
+        bool(true)
+        ["maxBsonObjectSize"]=>
+        int(%d)
+        ["maxMessageSizeBytes"]=>
+        int(%d)
+        ["maxWriteBatchSize"]=>
+        int(%d)
+        ["localTime"]=>
+        object(MongoDB\BSON\UTCDateTime)#4 (1) {
+          ["milliseconds"]=>
+          int(%d)
+        }
+        ["maxWireVersion"]=>
+        int(%d)
+        ["minWireVersion"]=>
+        int(%d)
+        ["ok"]=>
+        float(1)
+      }
+      ["round_trip_time"]=>
+      int(%d)
+    }
+  }
+}

--- a/tests/MongoDBDriverManager_getServers.phpt
+++ b/tests/MongoDBDriverManager_getServers.phpt
@@ -1,0 +1,36 @@
+--TEST--
+MongoDB\Driver\Manager::getServers()
+--FILE--
+<?php
+function assertServerType($type) {
+    if ($type === MongoDB\Driver\Server::TYPE_STANDALONE) {
+        printf("Found standalone server type: %d\n", $type);
+    } else {
+        printf("Unexpected server type: %d\n", $type);
+    }
+}
+
+$manager = new MongoDB\Driver\Manager();
+
+$servers = $manager->getServers();
+printf("Known servers: %d\n", count($servers));
+
+echo "Pinging\n";
+$command = new MongoDB\Driver\Command(array('ping' => 1));
+$manager->executeCommand("test", $command);
+
+$servers = $manager->getServers();
+printf("Known servers: %d\n", count($servers));
+
+foreach ($servers as $server) {
+    printf("Found server: %s:%d\n", $server->getHost(), $server->getPort());
+    assertServerType($server->getType());
+}
+
+?>
+--EXPECTF--
+Known servers: 0
+Pinging
+Known servers: 1
+Found server: %s:%d
+Found standalone server type: 1


### PR DESCRIPTION
Note: Can't really merge this yet until libmongoc 1.4.0 has been properly released.