### PR TITLE
HHVM-239: Allow users to set a limit on acceptable staleness

### DIFF
--- a/config.cmake
+++ b/config.cmake
@@ -58,7 +58,9 @@ HHVM_EXTENSION(mongodb
  libmongoc/src/mongoc/mongoc-gridfs-file.c libmongoc/src/mongoc/mongoc-gridfs.c
  libmongoc/src/mongoc/mongoc-host-list.c
  libmongoc/src/mongoc/mongoc-index.c libmongoc/src/mongoc/mongoc-init.c
- libmongoc/src/mongoc/mongoc-list.c libmongoc/src/mongoc/mongoc-log.c
+ libmongoc/src/mongoc/mongoc-list.c
+ libmongoc/src/mongoc/mongoc-linux-distro-scanner.c
+ libmongoc/src/mongoc/mongoc-log.c
  libmongoc/src/mongoc/mongoc-matcher-op.c libmongoc/src/mongoc/mongoc-matcher.c
  libmongoc/src/mongoc/mongoc-memcmp.c
  libmongoc/src/mongoc/mongoc-metadata.c

--- a/tests/MongoDBDriverManager_debugInfo.phpt
+++ b/tests/MongoDBDriverManager_debugInfo.phpt
@@ -34,7 +34,7 @@ array(2) {
       ["is_passive"]=>
       bool(false)
       ["last_is_master"]=>
-      array(8) {
+      array(9) {
         ["ismaster"]=>
         bool(true)
         ["maxBsonObjectSize"]=>
@@ -46,12 +46,14 @@ array(2) {
         ["localTime"]=>
         object(MongoDB\BSON\UTCDateTime)#%d (1) {
           ["milliseconds"]=>
-          int(%d)
+          string(%d) "%d"
         }
         ["maxWireVersion"]=>
         int(%d)
         ["minWireVersion"]=>
         int(%d)
+        ["readOnly"]=>
+        bool(false)
         ["ok"]=>
         float(1)
       }

--- a/tests/MongoDBDriverManager_maxStalenessMS-001.phpt
+++ b/tests/MongoDBDriverManager_maxStalenessMS-001.phpt
@@ -1,0 +1,11 @@
+--TEST--
+MongoDB\Driver\Manager: maxStalenessMS
+--FILE--
+<?php
+// They both should work, and produce no output. We're not testing whether the flag actually does something
+$manager = new MongoDB\Driver\Manager("mongodb://localhost/?readPreference=SECONDARY&maxStalenessMS=1231");
+$manager = new MongoDB\Driver\Manager("mongodb://localhost/?readPreference=SECONDARY", [ 'maxStalenessMS' => 1231 ] );
+?>
+==DONE==
+--EXPECTF--
+==DONE==

--- a/tests/MongoDBDriverManager_maxStalenessMS-001.phpt
+++ b/tests/MongoDBDriverManager_maxStalenessMS-001.phpt
@@ -5,6 +5,8 @@ MongoDB\Driver\Manager: maxStalenessMS
 // They both should work, and produce no output. We're not testing whether the flag actually does something
 $manager = new MongoDB\Driver\Manager("mongodb://localhost/?readPreference=SECONDARY&maxStalenessMS=1231");
 $manager = new MongoDB\Driver\Manager("mongodb://localhost/?readPreference=SECONDARY", [ 'maxStalenessMS' => 1231 ] );
+$manager = new MongoDB\Driver\Manager("mongodb://localhost/?readPreference=SECONDARY&maxstalenessms=1231");
+$manager = new MongoDB\Driver\Manager("mongodb://localhost/?readPreference=SECONDARY", [ 'maxstalenessms' => 1231 ] );
 ?>
 ==DONE==
 --EXPECTF--

--- a/tests/MongoDBDriverManager_maxStalenessMS_error-001.phpt
+++ b/tests/MongoDBDriverManager_maxStalenessMS_error-001.phpt
@@ -3,7 +3,19 @@ MongoDB\Driver\Manager: maxStalenessMS
 --FILE--
 <?php
 try {
+	$manager = new MongoDB\Driver\Manager("mongodb://localhost/?maxstalenessms=1231");
+} catch ( MongoDB\Driver\Exception\InvalidArgumentException $e ) {
+	echo $e->getMessage(), "\n";
+}
+
+try {
 	$manager = new MongoDB\Driver\Manager("mongodb://localhost/?maxStalenessMS=1231");
+} catch ( MongoDB\Driver\Exception\InvalidArgumentException $e ) {
+	echo $e->getMessage(), "\n";
+}
+
+try {
+	$manager = new MongoDB\Driver\Manager("mongodb://localhost/", [ 'maxstalenessms' => 1231 ] );
 } catch ( MongoDB\Driver\Exception\InvalidArgumentException $e ) {
 	echo $e->getMessage(), "\n";
 }
@@ -15,5 +27,7 @@ try {
 }
 ?>
 --EXPECTF--
+Failed to parse MongoDB URI: 'mongodb://localhost/?maxstalenessms=1231'
 Failed to parse MongoDB URI: 'mongodb://localhost/?maxStalenessMS=1231'
+Primary read preference mode conflicts with maxStalenessMS
 Primary read preference mode conflicts with maxStalenessMS

--- a/tests/MongoDBDriverManager_maxStalenessMS_error-001.phpt
+++ b/tests/MongoDBDriverManager_maxStalenessMS_error-001.phpt
@@ -1,0 +1,19 @@
+--TEST--
+MongoDB\Driver\Manager: maxStalenessMS
+--FILE--
+<?php
+try {
+	$manager = new MongoDB\Driver\Manager("mongodb://localhost/?maxStalenessMS=1231");
+} catch ( MongoDB\Driver\Exception\InvalidArgumentException $e ) {
+	echo $e->getMessage(), "\n";
+}
+
+try {
+	$manager = new MongoDB\Driver\Manager("mongodb://localhost/", [ 'maxStalenessMS' => 1231 ] );
+} catch ( MongoDB\Driver\Exception\InvalidArgumentException $e ) {
+	echo $e->getMessage(), "\n";
+}
+?>
+--EXPECTF--
+Failed to parse MongoDB URI: 'mongodb://localhost/?maxStalenessMS=1231'
+Primary read preference mode conflicts with maxStalenessMS


### PR DESCRIPTION
Depends on #126 (and sorry for the random test fix for tests/MongoDBDriverManager_debugInfo.phpt)