### PR TITLE
Do not wrap example Regex pattern with delimiters

### DIFF
--- a/tests/json-serialize-regex-001.phpt
+++ b/tests/json-serialize-regex-001.phpt
@@ -3,7 +3,7 @@ JsonSerializable: Regex
 --FILE--
 <?php
 $doc = [
-	'foo' => new MongoDB\BSON\Regex( "/foo/", "i" )
+	'foo' => new MongoDB\BSON\Regex( "pattern", "i" )
 ];
 
 echo MongoDB\BSON\toJSON( \MongoDB\BSON\fromPHP( $doc ) ), "\n";
@@ -13,13 +13,13 @@ echo $d, "\n";
 var_dump( \MongoDB\BSON\toPHP( \MongoDB\BSON\fromJSON( $d ) ) );
 ?>
 --EXPECTF--
-{ "foo" : { "$regex" : "/foo/", "$options" : "i" } }
-{"foo":{"$regex":"\/foo\/","$options":"i"}}
+{ "foo" : { "$regex" : "pattern", "$options" : "i" } }
+{"foo":{"$regex":"pattern","$options":"i"}}
 object(stdClass)#%d (%d) {
   ["foo"]=>
   object(MongoDB\BSON\Regex)#%d (%d) {
     ["pattern"]=>
-    string(%d) "/foo/"
+    string(%d) "pattern"
     ["flags"]=>
     string(%d) "i"
   }

--- a/tests/json-serialize-regex-002.phpt
+++ b/tests/json-serialize-regex-002.phpt
@@ -3,7 +3,7 @@ JsonSerializable: Regex without flags
 --FILE--
 <?php
 $doc = [
-	'foo' => new MongoDB\BSON\Regex( "/foo/" )
+	'foo' => new MongoDB\BSON\Regex( "pattern" )
 ];
 
 echo MongoDB\BSON\toJSON( \MongoDB\BSON\fromPHP( $doc ) ), "\n";
@@ -13,13 +13,13 @@ echo $d, "\n";
 var_dump( \MongoDB\BSON\toPHP( \MongoDB\BSON\fromJSON( $d ) ) );
 ?>
 --EXPECTF--
-{ "foo" : { "$regex" : "/foo/", "$options" : "" } }
-{"foo":{"$regex":"\/foo\/","$options":""}}
+{ "foo" : { "$regex" : "pattern", "$options" : "" } }
+{"foo":{"$regex":"pattern","$options":""}}
 object(stdClass)#%d (%d) {
   ["foo"]=>
   object(MongoDB\BSON\Regex)#%d (%d) {
     ["pattern"]=>
-    string(%d) "/foo/"
+    string(%d) "pattern"
     ["flags"]=>
     string(%d) ""
   }


### PR DESCRIPTION
The first argument to the Regex constructor is the pattern string itself. We shouldn't use delimiters in an example value within a test, as it may lead users to incorrectly believe that delimiters are expected.