### PR TITLE
HHVM-273: Do not eval bson_error_t.message as boolean

### DIFF
--- a/src/MongoDB/BSON/functions.cpp
+++ b/src/MongoDB/BSON/functions.cpp
@@ -64,7 +64,7 @@ Variant HHVM_FUNCTION(MongoDBBsonFromJson, const String &data)
 
 		return s;
 	} else {
-		throw MongoDriver::Utils::throwUnexpectedValueException(error.message ? error.message : "Error parsing JSON");
+		throw MongoDriver::Utils::throwUnexpectedValueException(error.domain == BSON_ERROR_JSON ? error.message : "Error parsing JSON");
 		return Variant();
 	}
 }


### PR DESCRIPTION
https://jira.mongodb.org/browse/HHVM-273