### PR TITLE
Fix 5 memory leaks.

### DIFF
--- a/src/MongoDB/Driver/Cursor.h
+++ b/src/MongoDB/Driver/Cursor.h
@@ -52,6 +52,8 @@ class MongoDBDriverCursorData
 
 		void sweep() {
 			mongoc_cursor_destroy(cursor);
+			free(m_db);
+			free(m_collection);
 		}
 
 		MongoDBDriverCursorData() {

--- a/src/MongoDB/Driver/Manager.cpp
+++ b/src/MongoDB/Driver/Manager.cpp
@@ -713,11 +713,14 @@ void HHVM_METHOD(MongoDBDriverManager, __construct, const String &dsn, const Arr
 
 	if (options.exists(s_MongoDBDriverManager_appname)) {
 		if (!mongoc_uri_set_appname(uri, options[s_MongoDBDriverManager_appname].toString().c_str())) {
+			mongoc_uri_destroy(uri);
 			throw MongoDriver::Utils::throwInvalidArgumentException("Invalid appname value: '" + options[s_MongoDBDriverManager_appname].toString() + "'");
 		}
 	}
 
 	client = Pool::GetClient(data->m_hash, uri);
+
+	mongoc_uri_destroy(uri);
 
 	if (!client) {
 		throw MongoDriver::Utils::throwRunTimeException("Failed to create Manager from URI: '" + dsn + "'");

--- a/src/MongoDB/Driver/Server.cpp
+++ b/src/MongoDB/Driver/Server.cpp
@@ -80,6 +80,7 @@ Object hippo_mongo_driver_server_create_from_id(mongoc_client_t *client, uint32_
 	}
 
 	tmp->o_set(s_MongoDriverServer___serverId, mongoc_server_description_host(sd)->host_and_port, s_MongoDriverServer_className);
+	mongoc_server_description_destroy(sd);
 
 	MongoDBDriverServerData* result_data = Native::data<MongoDBDriverServerData>(tmp);
 

--- a/src/MongoDB/Driver/WriteConcern.h
+++ b/src/MongoDB/Driver/WriteConcern.h
@@ -34,7 +34,7 @@ class MongoDBDriverWriteConcernData
 		static Class* getClass();
 
 		void sweep() {
-			/* do nothing */
+			mongoc_write_concern_destroy(m_write_concern);
 		}
 
 		~MongoDBDriverWriteConcernData() {

--- a/utils.cpp
+++ b/utils.cpp
@@ -304,7 +304,7 @@ HPHP::Object Utils::doExecuteCommand(const char *db, mongoc_client_t *client, in
 		/* This throws an exception upon error */
 		hippo_advance_cursor_and_check_for_error(cmd_cursor);
 
-		return HPHP::hippo_cursor_init_for_command(cmd_cursor, client, db, command, readPreference);
+		cursor = cmd_cursor;
 	}
 
 	/* Prepare result */


### PR DESCRIPTION
We were seeing huge memory consumption and so we used `valgrind` and `jemalloc` to track them down. The one in `doExecuteCommand()` was the biggest one for us.

Here are the results: ![Graph of memory](http://i.imgur.com/WtIubGL.png)

The bottom-most line is the machine with this patch applied.